### PR TITLE
Fix for escaped separators

### DIFF
--- a/table_cleaner.py
+++ b/table_cleaner.py
@@ -65,8 +65,23 @@ class TableCleanerCommand(table_commons.TextCommand):
 
     # Split the lines by a separator
     def split_lines(self, lines, separator):
+
         for line in lines:
-            line[1] = line[1].split(separator)
+
+            # if there is no escaped separator, just use normal version
+            if "\\" + separator not in line[1]:
+                line[1] = line[1].split(separator)
+
+            # if there is escaped separator in table (eg: \&)
+            else:
+                temp_line = []
+                last_i = 0
+                for i in xrange(len(line[1])):
+                    if line[1][i] == separator and line[1][i-1] != "\\":
+                        temp_line.append(line[1][last_i:i])
+                        last_i = i+1
+                temp_line.append(line[1][last_i:])
+                line[1] = temp_line
 
         return lines
 


### PR DESCRIPTION
I was finding myself using this plugin a lot with LaTeX tables that had the `&` symbol as content within a cell, so had to escape it like `\&`. Since the plugin didn't know I was escaping this separator, the tables weren't being aligned as it was supposed.

Here's an unaligned table:

```
a1 \& a2 & b & c \\
a & b & c \\
```

aligning with this fix:

```
a1 \& a2 & b & c \\ 
a        & b & c \\ 
```

aligning without this fix:

```
a1 \ & a2 & b    & c \\
a    & b  & c \\ 
a & b & c \\
```

I am even getting a new line (this only happens when the number of separators is different between lines though, but, even if there is a equal number of separator between lines, the `\` and the `&` get separated, which isn't intended).

Hope you find it useful too. Cheers.
